### PR TITLE
[feat] Board 및 Comment 엔티티를 설계한다

### DIFF
--- a/src/main/java/com/Chumaengi/chumaengi/board/domain/Board.java
+++ b/src/main/java/com/Chumaengi/chumaengi/board/domain/Board.java
@@ -1,0 +1,71 @@
+package com.Chumaengi.chumaengi.board.domain;
+
+import com.Chumaengi.chumaengi.board.exception.BoardErrorCode;
+import com.Chumaengi.chumaengi.comment.domain.Comment;
+import com.Chumaengi.chumaengi.global.BaseTimeEntity;
+import com.Chumaengi.chumaengi.global.exception.ChumaengiException;
+import com.Chumaengi.chumaengi.member.domain.Member;
+import lombok.*;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static javax.persistence.CascadeType.PERSIST;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name="board")
+public class Board extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Column(name = "view")
+    private int view;
+
+    @Column(name = "category")
+    private Category category;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "writer_id", referencedColumnName = "id", nullable = false)
+    private Member writer;
+
+    // 게시글 삭제시 달려있는 댓글 모두 삭제
+    @OneToMany(mappedBy = "board", cascade = PERSIST, orphanRemoval = true)
+    private List<Comment> commentList = new ArrayList<>();
+
+    @Builder
+    public Board(Member writer, String title, String content, Category category){
+        this.writer = writer;
+        this.title = title;
+        this.content = content;
+        this.category = category;
+        this.view = 0;
+    }
+
+    public static Board createBoard(Member writer, String title, String content, String category){
+        return new Board(writer, title, content, categoryStringToEnum(category));
+    }
+
+    public void addComment(Member writer, String content){ // 부모 댓글 추가
+        commentList.add(Comment.createComment(writer, this, null, content));
+    }
+
+    // 입력받은 문자열이 없다면 에러 반환, 있다면 문자열을 enum으로 변환
+    private static Category categoryStringToEnum(String categoryValue) {
+        return Arrays.stream(Category.values())
+                .filter(category -> category.getValue().equals(categoryValue))
+                .findFirst()
+                .orElseThrow(() -> new ChumaengiException(BoardErrorCode.CATEGORY_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/Chumaengi/chumaengi/board/domain/BoardRepository.java
+++ b/src/main/java/com/Chumaengi/chumaengi/board/domain/BoardRepository.java
@@ -1,0 +1,6 @@
+package com.Chumaengi.chumaengi.board.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+}

--- a/src/main/java/com/Chumaengi/chumaengi/board/domain/Category.java
+++ b/src/main/java/com/Chumaengi/chumaengi/board/domain/Category.java
@@ -1,0 +1,15 @@
+package com.Chumaengi.chumaengi.board.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Category {
+    Question("질문"),
+    BoardNotice("공지사항"),
+    Information("정보공유")
+    ;
+
+    private final String value;
+}

--- a/src/main/java/com/Chumaengi/chumaengi/board/exception/BoardErrorCode.java
+++ b/src/main/java/com/Chumaengi/chumaengi/board/exception/BoardErrorCode.java
@@ -1,0 +1,18 @@
+package com.Chumaengi.chumaengi.board.exception;
+
+import com.Chumaengi.chumaengi.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum BoardErrorCode implements ErrorCode {
+    BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD_001", "회원 정보를 찾을 수 없습니다."),
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD_002", "카테고리 정보를 찾을 수 없습니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String errorCode;
+    private final String message;
+}

--- a/src/main/java/com/Chumaengi/chumaengi/comment/domain/Comment.java
+++ b/src/main/java/com/Chumaengi/chumaengi/comment/domain/Comment.java
@@ -1,0 +1,59 @@
+package com.Chumaengi.chumaengi.comment.domain;
+
+import com.Chumaengi.chumaengi.board.domain.Board;
+import com.Chumaengi.chumaengi.global.BaseTimeEntity;
+import com.Chumaengi.chumaengi.member.domain.Member;
+import com.fasterxml.jackson.databind.ser.Serializers;
+import lombok.*;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import static javax.persistence.CascadeType.PERSIST;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "comment")
+public class Comment extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id") // 부모 댓글 없는 경우 null
+    private Comment parent;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "writer_id", referencedColumnName = "id", nullable = false)
+    private Member writer;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "board_id", referencedColumnName = "id", nullable = false)
+    private Board board;
+
+    // 부모 댓글 삭제시 달려있는 자식 댓글 모두 삭제
+    @OneToMany(mappedBy = "parent", cascade = PERSIST, orphanRemoval = true)
+    private List<Comment> childList = new ArrayList<>();
+
+    @Builder
+    public Comment(Member writer, Board board, Comment parent, String content){
+        this.writer = writer;
+        this.board = board;
+        this.parent = parent;
+        this.content = content;
+    }
+
+    public static Comment createComment(Member writer, Board board, Comment parent, String content){
+        return new Comment(writer, board, parent, content);
+    }
+
+    public void addChildComment(Member writer, Board board, String content) { // 대댓글 추가
+        childList.add(Comment.createComment(writer, board, this, content));
+    }
+}

--- a/src/main/java/com/Chumaengi/chumaengi/comment/domain/CommentRepository.java
+++ b/src/main/java/com/Chumaengi/chumaengi/comment/domain/CommentRepository.java
@@ -1,0 +1,6 @@
+package com.Chumaengi.chumaengi.comment.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/Chumaengi/chumaengi/member/domain/Member.java
+++ b/src/main/java/com/Chumaengi/chumaengi/member/domain/Member.java
@@ -1,11 +1,14 @@
 package com.Chumaengi.chumaengi.member.domain;
 
+import com.Chumaengi.chumaengi.board.domain.Board;
 import com.Chumaengi.chumaengi.global.BaseTimeEntity;
 import lombok.*;
 
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+
+import static javax.persistence.CascadeType.PERSIST;
 
 @Getter
 @Builder
@@ -36,6 +39,10 @@ public class Member extends BaseTimeEntity {
     @OneToMany(mappedBy = "member", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     @Builder.Default
     private List<Authority> roles = new ArrayList<>();
+
+    // 회원 탈퇴시 작성한 게시글 모두 삭제
+    @OneToMany(mappedBy = "writer", cascade = PERSIST, orphanRemoval = true)
+    private List<Board> boardList = new ArrayList<>();
 
     @Builder
     public Member(String name, String email, String password, String nickname) {

--- a/src/test/java/com/Chumaengi/chumaengi/board/domain/BoardRepositoryTest.java
+++ b/src/test/java/com/Chumaengi/chumaengi/board/domain/BoardRepositoryTest.java
@@ -1,0 +1,58 @@
+package com.Chumaengi.chumaengi.board.domain;
+
+import com.Chumaengi.chumaengi.comment.domain.CommentRepository;
+import com.Chumaengi.chumaengi.global.config.JpaAuditingConfig;
+import com.Chumaengi.chumaengi.member.domain.Member;
+import com.Chumaengi.chumaengi.member.domain.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.Chumaengi.chumaengi.board.domain.Category.Question;
+import static com.Chumaengi.chumaengi.fixture.BoardFixture.BOARD_0;
+import static com.Chumaengi.chumaengi.fixture.MemberFixture.SUNKYOUNG;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+@DisplayName("Board [Repository Layer] BoardRepository 테스트")
+public class BoardRepositoryTest {
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Test
+    @DisplayName("게시글을 생성한다")
+    void saveBoard() {
+        //given
+        Member writer = memberRepository.save(SUNKYOUNG.toMember());
+        boardRepository.save(BOARD_0.toBoard(writer));
+        LocalDateTime now = LocalDateTime.of(2023,6,21,0,0,0);
+
+        //when
+        List<Board> boardList = boardRepository.findAll();
+
+        //then
+        Board board = boardList.get(0);
+
+        assertAll(
+                () -> assertThat(board.getWriter()).isEqualTo(writer),
+                () -> assertThat(board.getTitle()).isEqualTo(BOARD_0.getTitle()),
+                () -> assertThat(board.getContent()).isEqualTo(BOARD_0.getContent()),
+                () -> assertThat(board.getCategory()).isEqualTo(Question),
+                () -> assertThat(board.getCreatedDate()).isAfter(now),
+                () -> assertThat(board.getModifiedDate()).isAfter(now)
+        );
+    }
+}

--- a/src/test/java/com/Chumaengi/chumaengi/comment/domain/CommentRepositoryTest.java
+++ b/src/test/java/com/Chumaengi/chumaengi/comment/domain/CommentRepositoryTest.java
@@ -1,0 +1,94 @@
+package com.Chumaengi.chumaengi.comment.domain;
+
+import com.Chumaengi.chumaengi.board.domain.Board;
+import com.Chumaengi.chumaengi.board.domain.BoardRepository;
+import com.Chumaengi.chumaengi.global.config.JpaAuditingConfig;
+import com.Chumaengi.chumaengi.member.domain.Member;
+import com.Chumaengi.chumaengi.member.domain.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.Chumaengi.chumaengi.fixture.BoardFixture.BOARD_0;
+import static com.Chumaengi.chumaengi.fixture.ChildCommentFixture.*;
+import static com.Chumaengi.chumaengi.fixture.CommentFixture.COMMENT_0;
+import static com.Chumaengi.chumaengi.fixture.MemberFixture.SUNKYOUNG;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+@DisplayName("Comment [Repository Layer] CommentRepository 테스트")
+public class CommentRepositoryTest {
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    private Member writer;
+    private Board board;
+    private Comment parentComment;
+
+    @BeforeEach
+    void setUp() {
+        writer = memberRepository.save(SUNKYOUNG.toMember());
+        board = boardRepository.save(BOARD_0.toBoard(writer));
+        parentComment = commentRepository.save(COMMENT_0.toComment(writer, board));
+    }
+
+    @Test
+    @DisplayName("댓글을 생성한다")
+    void saveComment() {
+        //given
+        LocalDateTime now = LocalDateTime.of(2023,6,21,0,0,0);
+
+        //when
+        List<Comment> commentList = commentRepository.findAll();
+
+        //then
+        Comment comment = commentList.get(0);
+
+        assertAll(
+                () -> assertThat(comment.getWriter()).isEqualTo(writer),
+                () -> assertThat(comment.getBoard()).isEqualTo(board),
+                () -> assertThat(comment.getContent()).isEqualTo(COMMENT_0.getContent()),
+                () -> assertThat(comment.getParent()).isEqualTo(null),
+                () -> assertThat(comment.getCreatedDate()).isAfter(now),
+                () -> assertThat(comment.getModifiedDate()).isAfter(now)
+        );
+    }
+
+    @Test
+    @DisplayName("대댓글을 생성한다")
+    void saveChildComment() {
+        //given
+        commentRepository.save(CHILD_COMMENT_0.toChildComment(writer, board, parentComment));
+        LocalDateTime now = LocalDateTime.of(2023, 6, 21, 0, 0, 0);
+
+        //when
+        List<Comment> commentList = commentRepository.findAll();
+
+        //then
+        Comment childComment = commentList.get(1);
+
+        assertAll(
+                () -> assertThat(childComment.getWriter()).isEqualTo(writer),
+                () -> assertThat(childComment.getBoard()).isEqualTo(board),
+                () -> assertThat(childComment.getContent()).isEqualTo(CHILD_COMMENT_0.getContent()),
+                () -> assertThat(childComment.getParent()).isEqualTo(parentComment),
+                () -> assertThat(childComment.getCreatedDate()).isAfter(now),
+                () -> assertThat(childComment.getModifiedDate()).isAfter(now)
+        );
+    }
+}

--- a/src/test/java/com/Chumaengi/chumaengi/fixture/BoardFixture.java
+++ b/src/test/java/com/Chumaengi/chumaengi/fixture/BoardFixture.java
@@ -1,0 +1,22 @@
+package com.Chumaengi.chumaengi.fixture;
+
+import com.Chumaengi.chumaengi.board.domain.Board;
+import com.Chumaengi.chumaengi.member.domain.Member;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BoardFixture {
+    BOARD_0("제목0", "내용0", "질문"),
+    BOARD_1("제목1", "내용1", "공지사항"),
+    BOARD_2("제목2", "내용2", "정보공유"),
+    ;
+
+    private final String title;
+    private final String content;
+    private final String category;
+
+    public Board toBoard(Member writer) { return Board.createBoard(writer, title, content, category); }
+
+}

--- a/src/test/java/com/Chumaengi/chumaengi/fixture/ChildCommentFixture.java
+++ b/src/test/java/com/Chumaengi/chumaengi/fixture/ChildCommentFixture.java
@@ -1,0 +1,23 @@
+package com.Chumaengi.chumaengi.fixture;
+
+import com.Chumaengi.chumaengi.board.domain.Board;
+import com.Chumaengi.chumaengi.comment.domain.Comment;
+import com.Chumaengi.chumaengi.member.domain.Member;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChildCommentFixture {
+    CHILD_COMMENT_0("대댓글0"),
+    CHILD_COMMENT_1("대댓글1"),
+    CHILD_COMMENT_2("대댓글2"),
+    CHILD_COMMENT_3("대댓글3")
+    ;
+
+    private final String content;
+
+    public Comment toChildComment(Member writer, Board board, Comment parent) {
+        return Comment.createComment(writer, board, parent, content);
+    }
+}

--- a/src/test/java/com/Chumaengi/chumaengi/fixture/CommentFixture.java
+++ b/src/test/java/com/Chumaengi/chumaengi/fixture/CommentFixture.java
@@ -1,0 +1,23 @@
+package com.Chumaengi.chumaengi.fixture;
+
+import com.Chumaengi.chumaengi.board.domain.Board;
+import com.Chumaengi.chumaengi.comment.domain.Comment;
+import com.Chumaengi.chumaengi.member.domain.Member;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommentFixture {
+    COMMENT_0("댓글0", null),
+    COMMENT_1("댓글1", null),
+    COMMENT_2("댓글2", null),
+    ;
+
+    private final String content;
+    private final Comment parent;
+
+    public Comment toComment(Member writer, Board board) {
+        return Comment.createComment(writer, board, parent, content);
+    }
+}

--- a/src/test/java/com/Chumaengi/chumaengi/member/domain/MemberRepositoryTest.java
+++ b/src/test/java/com/Chumaengi/chumaengi/member/domain/MemberRepositoryTest.java
@@ -22,7 +22,7 @@ public class MemberRepositoryTest {
     MemberRepository memberRepository;
 
     @Test
-    @DisplayName("회원을 저장한다")
+    @DisplayName("회원을 생성한다")
     void saveMember() {
         //given
         memberRepository.save(SUNKYOUNG.toMember());


### PR DESCRIPTION
### SUMMARY
Board 및 Comment 엔티티를 설계한다

### DESCRIBE YOUR CHANGES
- Board 및 BoardRepository 구현
    - Category Enum으로 작성 
- Comment 및 CommentRepositoy 구현
   - parent 컬럼이 null인 경우 부모 댓글 
- 테스트 코드 작성
   - BoardRepositoryTest
   - CommentRepositoryTest  

### PR CHECKLIST
- [x] PR 템플릿에 맞춰서 작성하기
- [x] 모든 테스트 통과
- [x] 정상적으로 프로그램 실행 가능
- [x] 라벨 넣기
- [x] 불필요한 개행, 띄어쓰기, import문 제거

### OPTIONS

### ISSUE NUMBERS AND LINK
Closes #19 
