### PR TITLE
[feat] 회원 정보 수정/탈퇴 API를 구현한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 
 	//test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// Spring Rest Docs (With MockMvc)
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'

--- a/src/main/java/com/Chumaengi/chumaengi/auth/service/TokenService.java
+++ b/src/main/java/com/Chumaengi/chumaengi/auth/service/TokenService.java
@@ -30,7 +30,7 @@ public class TokenService {
     public String createRefreshToken(Member member) {
 
         String refresh_token = UUID.randomUUID().toString();
-        Token token = tokenRepository.save(Token.issueRefreshToken(member.getId(), refresh_token, 600));
+        Token token = tokenRepository.save(Token.issueRefreshToken(member.getId(), refresh_token, 6000));
 
         return token.getRefresh_token();
     }
@@ -46,7 +46,7 @@ public class TokenService {
             // refresh 토큰 만료일자가 10초 미만이라면 새로운 refresh 토큰 부여
             if(token.getExpiration() < 10) {
                 token.updateRefreshToken(refreshToken);
-                tokenRepository.save(Token.issueRefreshToken(member.getId(), refreshToken, 600));
+                tokenRepository.save(Token.issueRefreshToken(member.getId(), refreshToken, 6000));
             }
 
             // 토큰이 같은지 비교, 다르다면 유효하지 않은 토큰

--- a/src/main/java/com/Chumaengi/chumaengi/member/controller/MemberApiController.java
+++ b/src/main/java/com/Chumaengi/chumaengi/member/controller/MemberApiController.java
@@ -1,0 +1,29 @@
+package com.Chumaengi.chumaengi.member.controller;
+
+import com.Chumaengi.chumaengi.member.controller.dto.MemberRequest;
+import com.Chumaengi.chumaengi.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user/{memberId}")
+public class MemberApiController {
+    private final MemberService memberService;
+
+    @PatchMapping
+    public ResponseEntity<Void> update(@PathVariable Long memberId,
+                                               @RequestBody @Valid MemberRequest request) {
+        memberService.update(memberId, request.getName(), request.getPassword(), request.getNickname());
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> delete(@PathVariable Long memberId) {
+        memberService.delete(memberId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/Chumaengi/chumaengi/member/controller/dto/MemberRequest.java
+++ b/src/main/java/com/Chumaengi/chumaengi/member/controller/dto/MemberRequest.java
@@ -1,0 +1,27 @@
+package com.Chumaengi.chumaengi.member.controller.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor
+public class MemberRequest {
+    @NotBlank(message = "수정할 이름을 작성해주세요")
+    private String name;
+
+    @NotBlank(message = "수정할 비밀번호를 작성해주세요")
+    private String password;
+
+    @NotBlank(message = "수정할 닉네임을 작성해주세요")
+    private String nickname;
+
+    @Builder
+    public MemberRequest(String name, String password, String nickname){
+        this.name = name;
+        this.password=password;
+        this.nickname=nickname;
+    }
+}

--- a/src/main/java/com/Chumaengi/chumaengi/member/domain/Member.java
+++ b/src/main/java/com/Chumaengi/chumaengi/member/domain/Member.java
@@ -64,4 +64,10 @@ public class Member extends BaseTimeEntity {
     public void setRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
+
+    public void update(String name, String password, String nickname) {
+        this.name = name;
+        this.password = password;
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/Chumaengi/chumaengi/member/service/MemberService.java
+++ b/src/main/java/com/Chumaengi/chumaengi/member/service/MemberService.java
@@ -1,0 +1,31 @@
+package com.Chumaengi.chumaengi.member.service;
+
+import com.Chumaengi.chumaengi.member.domain.Member;
+import com.Chumaengi.chumaengi.member.domain.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+    private final MemberFindService memberFindService;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void update(Long memberId, String name, String password, String nickname) {
+        Member member = memberFindService.findById(memberId);
+
+        member.update(name, passwordEncoder.encode(password), nickname);
+    }
+
+    @Transactional
+    public void delete(Long memberId) {
+        Member member = memberFindService.findById(memberId);
+
+        memberRepository.delete(member);
+    }
+}


### PR DESCRIPTION
### SUMMARY
회원 정보 수정/탈퇴 API를 구현한다
### DESCRIBE YOUR CHANGES
- 회원 정보 수정/탈퇴 API 구현
   - MemberRequest
   - MemberService
   - MemberApiController
- 테스트 (PostMan으로 진행)
### PR CHECKLIST
- [x] PR 템플릿에 맞춰서 작성하기
- [x] 모든 테스트 통과
- [x] 정상적으로 프로그램 실행 가능
- [x] 라벨 넣기
- [x] 불필요한 개행, 띄어쓰기, import문 제거

### OPTIONS
시간 관계상 테스트 코드를 생략하고 일단 PostMan으로 테스트 진행했습니다.
회원 정보 수정 후 로그인 되는 것과 탈퇴 후 로그인이 불가능한 것 테스트 완료했습니다. 
### ISSUE NUMBERS AND LINK
Closes #20 
