### PR TITLE
[feat] 게시글 등록/수정/삭제 API를 구현한다

### DIFF
--- a/src/main/java/com/Chumaengi/chumaengi/board/controller/BoardApiController.java
+++ b/src/main/java/com/Chumaengi/chumaengi/board/controller/BoardApiController.java
@@ -1,0 +1,37 @@
+package com.Chumaengi.chumaengi.board.controller;
+
+import com.Chumaengi.chumaengi.board.controller.dto.BoardRequest;
+import com.Chumaengi.chumaengi.board.service.BoardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/boards/{writerId}")
+public class BoardApiController {
+    private final BoardService boardService;
+
+    @PostMapping
+    public ResponseEntity<Void> create(@PathVariable Long writerId,
+                                       @RequestBody @Valid BoardRequest request) {
+        Long boardId = boardService.create(writerId, request.getTitle(), request.getContent(), request.getCategory());
+        return ResponseEntity.created(URI.create("/detail/"+boardId)).build();
+    }
+
+    @PatchMapping("/{boardId}")
+    public ResponseEntity<Void> update(@PathVariable Long writerId, @PathVariable Long boardId,
+                                       @RequestBody @Valid BoardRequest request) {
+        boardService.update(writerId, boardId, request.getTitle(), request.getContent(), request.getCategory());
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{boardId}")
+    public ResponseEntity<Void> delete(@PathVariable Long writerId, @PathVariable Long boardId) {
+        boardService.delete(writerId, boardId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/Chumaengi/chumaengi/board/controller/dto/BoardRequest.java
+++ b/src/main/java/com/Chumaengi/chumaengi/board/controller/dto/BoardRequest.java
@@ -1,0 +1,27 @@
+package com.Chumaengi.chumaengi.board.controller.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor
+public class BoardRequest {
+    @NotBlank(message = "제목을 작성해주세요")
+    private String title;
+
+    @NotBlank(message = "내용을 작성해주세요")
+    private String content;
+
+    @NotBlank(message = "카테고리를 선택해주세요")
+    private String category;
+
+    @Builder
+    public BoardRequest(String title, String content, String category) {
+        this.title = title;
+        this.content = content;
+        this.category = category;
+    }
+}

--- a/src/main/java/com/Chumaengi/chumaengi/board/domain/Board.java
+++ b/src/main/java/com/Chumaengi/chumaengi/board/domain/Board.java
@@ -68,4 +68,10 @@ public class Board extends BaseTimeEntity {
                 .findFirst()
                 .orElseThrow(() -> new ChumaengiException(BoardErrorCode.CATEGORY_NOT_FOUND));
     }
+
+    public void update (String updateTitle, String updateContent, String updateCategory) {
+        this.title = updateTitle;
+        this.content = updateContent;
+        this.category = categoryStringToEnum(updateCategory);
+    }
 }

--- a/src/main/java/com/Chumaengi/chumaengi/board/exception/BoardErrorCode.java
+++ b/src/main/java/com/Chumaengi/chumaengi/board/exception/BoardErrorCode.java
@@ -8,8 +8,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum BoardErrorCode implements ErrorCode {
-    BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD_001", "회원 정보를 찾을 수 없습니다."),
-    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD_002", "카테고리 정보를 찾을 수 없습니다.")
+    BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD_001", "게시글 정보를 찾을 수 없습니다."),
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD_002", "카테고리 정보를 찾을 수 없습니다."),
+    USER_IS_NOT_BOARD_WRITER(HttpStatus.CONFLICT, "BOARD_003", "게시글 작성자가 아닙니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/Chumaengi/chumaengi/board/service/BoardFindService.java
+++ b/src/main/java/com/Chumaengi/chumaengi/board/service/BoardFindService.java
@@ -1,0 +1,22 @@
+package com.Chumaengi.chumaengi.board.service;
+
+import com.Chumaengi.chumaengi.board.domain.Board;
+import com.Chumaengi.chumaengi.board.domain.BoardRepository;
+import com.Chumaengi.chumaengi.board.exception.BoardErrorCode;
+import com.Chumaengi.chumaengi.global.exception.ChumaengiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BoardFindService {
+    private final BoardRepository boardRepository;
+
+    @Transactional
+    public Board findById(Long boardId){
+        return boardRepository.findById(boardId)
+                .orElseThrow(() -> ChumaengiException.type(BoardErrorCode.BOARD_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/Chumaengi/chumaengi/board/service/BoardService.java
+++ b/src/main/java/com/Chumaengi/chumaengi/board/service/BoardService.java
@@ -1,0 +1,50 @@
+package com.Chumaengi.chumaengi.board.service;
+
+import com.Chumaengi.chumaengi.board.domain.Board;
+import com.Chumaengi.chumaengi.board.domain.BoardRepository;
+import com.Chumaengi.chumaengi.board.exception.BoardErrorCode;
+import com.Chumaengi.chumaengi.global.exception.ChumaengiException;
+import com.Chumaengi.chumaengi.member.domain.Member;
+import com.Chumaengi.chumaengi.member.service.MemberFindService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BoardService {
+    private final MemberFindService memberFindService;
+    private final BoardFindService boardFindService;
+    private final BoardRepository boardRepository;
+
+    @Transactional
+    public Long create(Long writerId, String title, String content, String category){
+        Member writer = memberFindService.findById(writerId);
+        Board board = Board.createBoard(writer, title, content, category);
+
+        return boardRepository.save(board).getId();
+    }
+
+    @Transactional
+    public void update(Long writerId, Long boardId, String title, String content, String category){
+        validateWriter(boardId, writerId);
+        Board board = boardFindService.findById(boardId);
+
+        board.update(title, content, category);
+    }
+
+    @Transactional
+    public void delete(Long writerId, Long boardId){
+        validateWriter(boardId, writerId);
+        boardRepository.deleteById(boardId);
+    }
+
+    private void validateWriter(Long boardId, Long writerId) {
+        Board board = boardFindService.findById(boardId);
+        if (!board.getWriter().getId().equals(writerId)) {
+            throw ChumaengiException.type(BoardErrorCode.USER_IS_NOT_BOARD_WRITER);
+        }
+    }
+}
+

--- a/src/main/java/com/Chumaengi/chumaengi/global/config/SecurityConfig.java
+++ b/src/main/java/com/Chumaengi/chumaengi/global/config/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
                 .authorizeRequests()
                 .antMatchers("/signup", "/login", "/refresh","/h2-console/**").permitAll()
                 .antMatchers("/admin/**").hasRole("ADMIN")
-                .antMatchers("/user/**").hasRole("USER")
+                .antMatchers("/user/**", "/boards/**").hasRole("USER")
                 .anyRequest().denyAll()
                 .and()
                 // JWT 인증 필터 적용


### PR DESCRIPTION
### SUMMARY
게시글 등록/수정/삭제 API를 구현한다
### DESCRIBE YOUR CHANGES
- 게시글 등록/수정/삭제 API 구현
   - BoardRequest
   - BoardService
       - validateWriter 메서드 작성 
   - BoardApiController
- SecurityConfig 설정
   - User 권한을 가진 사람은 /board/**로 접속할 수 있도록 설정
- BoardErrorCode 오타 수정
- 테스트 (PostMan)으로 진행  
### PR CHECKLIST
- [x] PR 템플릿에 맞춰서 작성하기
- [x] 모든 테스트 통과
- [x] 정상적으로 프로그램 실행 가능
- [x] 라벨 넣기
- [x] 불필요한 개행, 띄어쓰기, import문 제거

### OPTIONS

### ISSUE NUMBERS AND LINK
Closes #21 
