### PR TITLE
[feat] 댓글 등록/삭제 API를 구현한다

### DIFF
--- a/src/main/java/com/Chumaengi/chumaengi/board/controller/BoardApiController.java
+++ b/src/main/java/com/Chumaengi/chumaengi/board/controller/BoardApiController.java
@@ -11,7 +11,7 @@ import java.net.URI;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/boards/{writerId}")
+@RequestMapping("/api/boards/{writerId}")
 public class BoardApiController {
     private final BoardService boardService;
 

--- a/src/main/java/com/Chumaengi/chumaengi/comment/controller/CommentApiController.java
+++ b/src/main/java/com/Chumaengi/chumaengi/comment/controller/CommentApiController.java
@@ -1,0 +1,31 @@
+package com.Chumaengi.chumaengi.comment.controller;
+
+import com.Chumaengi.chumaengi.comment.controller.dto.CommentRequest;
+import com.Chumaengi.chumaengi.comment.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/comments/{writerId}")
+public class CommentApiController {
+    private final CommentService commentService;
+
+    @PostMapping("/{boardId}")
+    public ResponseEntity<Void> create(@PathVariable Long writerId, @PathVariable Long boardId,
+                                       @RequestBody @Valid CommentRequest request) {
+        commentService.create(writerId, boardId, request.getContent());
+        return ResponseEntity.created(URI.create("/boards/detail/" + boardId)).build();
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> delete(@PathVariable Long writerId, @PathVariable Long commentId) {
+        commentService.delete(writerId, commentId);
+        return ResponseEntity.ok().build();
+    }
+}
+

--- a/src/main/java/com/Chumaengi/chumaengi/comment/controller/dto/CommentRequest.java
+++ b/src/main/java/com/Chumaengi/chumaengi/comment/controller/dto/CommentRequest.java
@@ -1,0 +1,19 @@
+package com.Chumaengi.chumaengi.comment.controller.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor
+public class CommentRequest {
+    @NotBlank(message = "내용을 작성해주세요")
+    private String content;
+
+    @Builder
+    public CommentRequest(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/Chumaengi/chumaengi/comment/exception/CommentErrorCode.java
+++ b/src/main/java/com/Chumaengi/chumaengi/comment/exception/CommentErrorCode.java
@@ -1,0 +1,18 @@
+package com.Chumaengi.chumaengi.comment.exception;
+
+import com.Chumaengi.chumaengi.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommentErrorCode implements ErrorCode {
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_001", "댓글 정보를 찾을 수 없습니다."),
+    USER_IS_NOT_COMMENT_WRITER(HttpStatus.CONFLICT, "COMMENT_002", "댓글 작성자가 아닙니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String errorCode;
+    private final String message;
+}

--- a/src/main/java/com/Chumaengi/chumaengi/comment/service/CommentFindService.java
+++ b/src/main/java/com/Chumaengi/chumaengi/comment/service/CommentFindService.java
@@ -1,0 +1,21 @@
+package com.Chumaengi.chumaengi.comment.service;
+
+import com.Chumaengi.chumaengi.comment.domain.Comment;
+import com.Chumaengi.chumaengi.comment.domain.CommentRepository;
+import com.Chumaengi.chumaengi.comment.exception.CommentErrorCode;
+import com.Chumaengi.chumaengi.global.exception.ChumaengiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CommentFindService {
+    private final CommentRepository commentRepository;
+
+    public Comment findById(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> ChumaengiException.type(CommentErrorCode.COMMENT_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/Chumaengi/chumaengi/comment/service/CommentService.java
+++ b/src/main/java/com/Chumaengi/chumaengi/comment/service/CommentService.java
@@ -1,0 +1,46 @@
+package com.Chumaengi.chumaengi.comment.service;
+
+import com.Chumaengi.chumaengi.board.domain.Board;
+import com.Chumaengi.chumaengi.board.service.BoardFindService;
+import com.Chumaengi.chumaengi.comment.domain.Comment;
+import com.Chumaengi.chumaengi.comment.domain.CommentRepository;
+import com.Chumaengi.chumaengi.comment.exception.CommentErrorCode;
+import com.Chumaengi.chumaengi.global.exception.ChumaengiException;
+import com.Chumaengi.chumaengi.member.domain.Member;
+import com.Chumaengi.chumaengi.member.service.MemberFindService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CommentService {
+    private final MemberFindService memberFindService;
+    private final BoardFindService boardFindService;
+    private final CommentFindService commentFindService;
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public Long create(Long writerId, Long boardId, String content){
+        Member writer = memberFindService.findById(writerId);
+        Board board = boardFindService.findById(boardId);
+        Comment comment = Comment.createComment(writer, board, null, content);
+
+        return commentRepository.save(comment).getId();
+    }
+
+    @Transactional
+    public void delete(Long writerId, Long commentId){
+        validateWriter(commentId, writerId);
+        commentRepository.deleteById(commentId);
+    }
+
+    private void validateWriter(Long commentId, Long writerId) {
+        Comment comment = commentFindService.findById(commentId);
+        if (!comment.getWriter().getId().equals(writerId)) {
+            throw ChumaengiException.type(CommentErrorCode.USER_IS_NOT_COMMENT_WRITER);
+        }
+    }
+}
+

--- a/src/main/java/com/Chumaengi/chumaengi/global/config/SecurityConfig.java
+++ b/src/main/java/com/Chumaengi/chumaengi/global/config/SecurityConfig.java
@@ -63,8 +63,8 @@ public class SecurityConfig {
                 // 조건별로 요청 허용/제한 설정
                 .authorizeRequests()
                 .antMatchers("/signup", "/login", "/refresh","/h2-console/**").permitAll()
-                .antMatchers("/admin/**").hasRole("ADMIN")
-                .antMatchers("/user/**", "/boards/**").hasRole("USER")
+                .antMatchers("/api/admin/**").hasRole("ADMIN")
+                .antMatchers("/api/users/**", "/api/boards/**", "/api/comments/**").hasRole("USER")
                 .anyRequest().denyAll()
                 .and()
                 // JWT 인증 필터 적용

--- a/src/main/java/com/Chumaengi/chumaengi/member/controller/MemberApiController.java
+++ b/src/main/java/com/Chumaengi/chumaengi/member/controller/MemberApiController.java
@@ -10,7 +10,7 @@ import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/user/{memberId}")
+@RequestMapping("/api/users/{memberId}")
 public class MemberApiController {
     private final MemberService memberService;
 


### PR DESCRIPTION
### SUMMARY
댓글 등록/삭제 API를 구현한다
### DESCRIBE YOUR CHANGES
- 댓글 등록/수정/삭제 API 구현
   - CommentRequest
   - CommentService
       - validateWriter 메서드 작성 
   - CommentApiController
   - User 권한을 가진 사람 접속할 수 있는 주소 수정
       - "/api/users/**" 
       - "/api/boards/**"
       - "/api/comments/**" 
- 테스트 (PostMan)으로 진행  
### PR CHECKLIST
- [x] PR 템플릿에 맞춰서 작성하기
- [x] 모든 테스트 통과
- [x] 정상적으로 프로그램 실행 가능
- [x] 라벨 넣기
- [x] 불필요한 개행, 띄어쓰기, import문 제거

### OPTIONS

### ISSUE NUMBERS AND LINK
Closes #22 
