### PR TITLE
[feat] 대댓글 등록/삭제 API를 구현한다

### DIFF
--- a/src/main/java/com/Chumaengi/chumaengi/comment/controller/CommentApiController.java
+++ b/src/main/java/com/Chumaengi/chumaengi/comment/controller/CommentApiController.java
@@ -27,5 +27,12 @@ public class CommentApiController {
         commentService.delete(writerId, commentId);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/{boardId}/{parentId}/child-comments")
+    public ResponseEntity<Void> createChild(@PathVariable Long writerId, @PathVariable Long boardId,
+                                            @PathVariable Long parentId, @RequestBody @Valid CommentRequest request) {
+        commentService.createChild(writerId, boardId, parentId, request.getContent());
+        return ResponseEntity.created(URI.create("/board/detail/" + boardId)).build();
+    }
 }
 

--- a/src/main/java/com/Chumaengi/chumaengi/comment/service/CommentService.java
+++ b/src/main/java/com/Chumaengi/chumaengi/comment/service/CommentService.java
@@ -36,6 +36,16 @@ public class CommentService {
         commentRepository.deleteById(commentId);
     }
 
+    @Transactional
+    public Long createChild(Long writerId, Long boardId, Long parentId, String content){
+        Member writer = memberFindService.findById(writerId);
+        Board board = boardFindService.findById(boardId);
+        Comment parentComment = commentFindService.findById(parentId);
+        Comment childComment = Comment.createComment(writer, board, parentComment, content);
+
+        return commentRepository.save(childComment).getId();
+    }
+
     private void validateWriter(Long commentId, Long writerId) {
         Comment comment = commentFindService.findById(commentId);
         if (!comment.getWriter().getId().equals(writerId)) {

--- a/src/test/java/com/Chumaengi/chumaengi/auth/controller/AuthApiControllerTest.java
+++ b/src/test/java/com/Chumaengi/chumaengi/auth/controller/AuthApiControllerTest.java
@@ -4,7 +4,7 @@ import com.Chumaengi.chumaengi.auth.controller.dto.AuthRequest;
 import com.Chumaengi.chumaengi.auth.exception.AuthErrorCode;
 import com.Chumaengi.chumaengi.global.exception.ChumaengiException;
 import com.Chumaengi.chumaengi.member.exception.MemberErrorCode;
-import common.ControllerTest;
+import com.Chumaengi.chumaengi.common.ControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/Chumaengi/chumaengi/common/ControllerTest.java
+++ b/src/test/java/com/Chumaengi/chumaengi/common/ControllerTest.java
@@ -1,4 +1,4 @@
-package common;
+package com.Chumaengi.chumaengi.common;
 
 import com.Chumaengi.chumaengi.auth.controller.AuthApiController;
 import com.Chumaengi.chumaengi.auth.security.JwtProvider;


### PR DESCRIPTION
### SUMMARY
대댓글 등록/삭제 API를 구현한다
### DESCRIBE YOUR CHANGES
- 대댓글 등록/삭제 API 구현
    - CommentService, CommentApiController
        -  대댓글 등록 api 작성
    - 대댓글 삭제는 댓글 삭제 api 사용 
- 테스트
    -  postman으로 테스트 완료 
### PR CHECKLIST
- [x] PR 템플릿에 맞춰서 작성하기
- [x] 모든 테스트 통과
- [x] 정상적으로 프로그램 실행 가능
- [x] 라벨 넣기
- [x] 불필요한 개행, 띄어쓰기, import문 제거

### OPTIONS

### ISSUE NUMBERS AND LINK
Closes #23
