### PR TITLE
[Feat] 카테고리별 게시글 상세조회 UI 구현 및 연결한다

### DIFF
--- a/src/main/java/com/Chumaengi/chumaengi/board/controller/BoardController.java
+++ b/src/main/java/com/Chumaengi/chumaengi/board/controller/BoardController.java
@@ -64,6 +64,7 @@ public class BoardController {
     public String boardDetail(@PathVariable Long boardId, Model model){
         BoardResponse boardResponse = boardService.findById(boardId);
         List<CommentListResponse> commentList = boardResponse.getCommentList();
+        System.out.println(commentList.get(0).getContent());
         if(commentList != null && !commentList.isEmpty()){
             model.addAttribute("commentList",commentList);
         }

--- a/src/main/java/com/Chumaengi/chumaengi/board/controller/BoardController.java
+++ b/src/main/java/com/Chumaengi/chumaengi/board/controller/BoardController.java
@@ -3,6 +3,7 @@ package com.Chumaengi.chumaengi.board.controller;
 import com.Chumaengi.chumaengi.board.controller.dto.BoardListResponse;
 import com.Chumaengi.chumaengi.board.controller.dto.BoardResponse;
 import com.Chumaengi.chumaengi.board.service.BoardService;
+import com.Chumaengi.chumaengi.comment.controller.dto.CommentListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,6 +13,8 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
 
 import static com.Chumaengi.chumaengi.board.domain.Board.categoryStringToEnum;
 
@@ -60,6 +63,11 @@ public class BoardController {
     @GetMapping("/detail/{boardId}")
     public String boardDetail(@PathVariable Long boardId, Model model){
         BoardResponse boardResponse = boardService.findById(boardId);
+        List<CommentListResponse> commentList = boardResponse.getCommentList();
+        if(commentList != null && !commentList.isEmpty()){
+            model.addAttribute("commentList",commentList);
+        }
+
         model.addAttribute("board",boardResponse);
 
         String category = boardResponse.getCategory().getValue();

--- a/src/main/java/com/Chumaengi/chumaengi/board/controller/dto/BoardResponse.java
+++ b/src/main/java/com/Chumaengi/chumaengi/board/controller/dto/BoardResponse.java
@@ -1,11 +1,13 @@
 package com.Chumaengi.chumaengi.board.controller.dto;
 
 import com.Chumaengi.chumaengi.board.domain.Category;
+import com.Chumaengi.chumaengi.comment.controller.dto.CommentListResponse;
 import com.Chumaengi.chumaengi.member.domain.Member;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 public class BoardResponse {
@@ -17,10 +19,12 @@ public class BoardResponse {
     private final LocalDateTime createdDate;
     private final Category category;
     private final Member member;
+    private final List<CommentListResponse> commentList;
 
     @Builder
     public BoardResponse(Long id, String title, String writer, String content,
-                         int view, LocalDateTime createdDate, Category category, Member member){
+                         int view, LocalDateTime createdDate, Category category,
+                         Member member, List<CommentListResponse> commentList){
         this.id = id;
         this.title = title;
         this.content = content;
@@ -29,5 +33,6 @@ public class BoardResponse {
         this.createdDate = createdDate;
         this.category = category;
         this.member = member;
+        this.commentList = commentList;
     }
 }

--- a/src/main/java/com/Chumaengi/chumaengi/board/service/BoardService.java
+++ b/src/main/java/com/Chumaengi/chumaengi/board/service/BoardService.java
@@ -6,6 +6,7 @@ import com.Chumaengi.chumaengi.board.domain.Board;
 import com.Chumaengi.chumaengi.board.domain.BoardRepository;
 import com.Chumaengi.chumaengi.board.domain.Category;
 import com.Chumaengi.chumaengi.board.exception.BoardErrorCode;
+import com.Chumaengi.chumaengi.comment.service.CommentService;
 import com.Chumaengi.chumaengi.global.exception.ChumaengiException;
 import com.Chumaengi.chumaengi.member.domain.Member;
 import com.Chumaengi.chumaengi.member.service.MemberFindService;
@@ -22,6 +23,7 @@ public class BoardService {
     private final MemberFindService memberFindService;
     private final BoardFindService boardFindService;
     private final BoardRepository boardRepository;
+    private final CommentService commentService;
 
     @Transactional
     public Long create(Long writerId, String title, String content, String category){
@@ -77,6 +79,7 @@ public class BoardService {
                 .createdDate(board.getCreatedDate())
                 .category(board.getCategory())
                 .member(board.getWriter())
+                .commentList(commentService.findByBoard(board))
                 .build();
     }
 }

--- a/src/main/java/com/Chumaengi/chumaengi/comment/controller/dto/CommentListResponse.java
+++ b/src/main/java/com/Chumaengi/chumaengi/comment/controller/dto/CommentListResponse.java
@@ -1,0 +1,26 @@
+package com.Chumaengi.chumaengi.comment.controller.dto;
+
+import com.Chumaengi.chumaengi.member.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CommentListResponse {
+    private final Long id;
+    private final String content;
+    private final String writer;
+    private final LocalDateTime createdDate;
+    private final Member member;
+
+    @Builder
+    public CommentListResponse(Long id, String content, String writer,
+                               LocalDateTime createdDate, Member member) {
+        this.id = id;
+        this.content = content;
+        this.writer = writer;
+        this.createdDate = createdDate;
+        this.member = member;
+    }
+}

--- a/src/main/java/com/Chumaengi/chumaengi/comment/controller/dto/CommentListResponse.java
+++ b/src/main/java/com/Chumaengi/chumaengi/comment/controller/dto/CommentListResponse.java
@@ -1,5 +1,6 @@
 package com.Chumaengi.chumaengi.comment.controller.dto;
 
+import com.Chumaengi.chumaengi.board.domain.Board;
 import com.Chumaengi.chumaengi.member.domain.Member;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,14 +14,16 @@ public class CommentListResponse {
     private final String writer;
     private final LocalDateTime createdDate;
     private final Member member;
+    private final Board board;
 
     @Builder
     public CommentListResponse(Long id, String content, String writer,
-                               LocalDateTime createdDate, Member member) {
+                               LocalDateTime createdDate, Member member, Board board) {
         this.id = id;
         this.content = content;
         this.writer = writer;
         this.createdDate = createdDate;
         this.member = member;
+        this.board = board;
     }
 }

--- a/src/main/java/com/Chumaengi/chumaengi/comment/domain/CommentRepository.java
+++ b/src/main/java/com/Chumaengi/chumaengi/comment/domain/CommentRepository.java
@@ -1,6 +1,10 @@
 package com.Chumaengi.chumaengi.comment.domain;
 
+import com.Chumaengi.chumaengi.board.domain.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByBoard(Board board);
 }

--- a/src/main/java/com/Chumaengi/chumaengi/comment/service/CommentService.java
+++ b/src/main/java/com/Chumaengi/chumaengi/comment/service/CommentService.java
@@ -2,6 +2,7 @@ package com.Chumaengi.chumaengi.comment.service;
 
 import com.Chumaengi.chumaengi.board.domain.Board;
 import com.Chumaengi.chumaengi.board.service.BoardFindService;
+import com.Chumaengi.chumaengi.comment.controller.dto.CommentListResponse;
 import com.Chumaengi.chumaengi.comment.domain.Comment;
 import com.Chumaengi.chumaengi.comment.domain.CommentRepository;
 import com.Chumaengi.chumaengi.comment.exception.CommentErrorCode;
@@ -11,6 +12,9 @@ import com.Chumaengi.chumaengi.member.service.MemberFindService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -44,6 +48,21 @@ public class CommentService {
         Comment childComment = Comment.createComment(writer, board, parentComment, content);
 
         return commentRepository.save(childComment).getId();
+    }
+
+    @Transactional
+    public List<CommentListResponse> findByBoard(Board board){
+        List<Comment> comments = commentRepository.findByBoard(board);
+        List<CommentListResponse> commentList = comments.stream().map(m -> CommentListResponse.builder()
+                .id(m.getId())
+                .content(m.getContent())
+                .writer(m.getWriter().getNickname())
+                .createdDate(m.getCreatedDate())
+                .member(m.getWriter())
+                .board(m.getBoard())
+                .build())
+                .collect(Collectors.toList());
+        return commentList;
     }
 
     private void validateWriter(Long commentId, Long writerId) {

--- a/src/main/resources/templates/boards/boardnotice_detail.html
+++ b/src/main/resources/templates/boards/boardnotice_detail.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <link rel="stylesheet" type="text/css" th:href="@{/css/login.css?v1}">
+  <link rel="stylesheet" type="text/css" th:href="@{/css/base.css?v1}">
+  <link rel="stylesheet" type="text/css" th:href="@{/css/board.css?v1}">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Nanum+Myeongjo:wght@700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600&display=swap" rel="stylesheet">
+  <title>Information Detail</title>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@500&family=Skranji&display=swap');
+  </style>
+  <link rel='stylesheet' href='/webjars/bootstrap/4.5.0/css/bootstrap.min.css'>
+  <script>
+    $('.toggleDiv').on('click',function (){
+      this.next().toggle();
+    });
+  </script>
+</head>
+<body>
+<header th:insert="common/header.html"></header>
+<div class="container">
+  <div class="row" id="detailTop">
+    <h2 class="mr-auto" style="margin: 0 0 10px 20px">공지사항</h2>
+    <button th:if="${session.role == 'ROLE_ADMIN'}"
+            class="signupBtn"  type="button" style="background:none;border:none;padding:10px">
+      <a th:href="@{|/boards/boardnotice_update|}"
+         style="text-decoration: none;color: lightslategray">
+        수정
+      </a>
+    </button>
+    <button id="boardNotice_list" type="button"
+            style="background:none;border:none;color: lightslategray;padding:10px;margin:10px 0">이전</button>
+  </div>
+  <table class="table">
+    <thead>
+    <tr class="text-center">
+      <th scope="col">글번호: <span  th:text="${board.id}"></span></th>
+      <th scope="col">제목: <span th:text="${board.title}"></span></th>
+      <th scope="col">작성자: <span th:text="${board.writer}"></span></th>
+    </tr>
+    </thead>
+  </table>
+  <h6 style="float: right;color: #999999">
+    작성일자: <span th:text="${#temporals.format(board.createdDate, 'yyyy-MM-dd HH:mm')}"></span>
+  </h6>
+  <br>
+  <div style="height: 600px;">
+    <h3 style="margin-top: 50px"><span th:text="${board.content}"></span></h3>
+  </div>
+</div>
+<footer th:insert="common/footer.html"></footer>
+<script src="/webjars/jquery/3.5.1/jquery.min.js"></script>
+<script src="/webjars/bootstrap/4.5.0/js/bootstrap.min.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/boards/information_detail.html
+++ b/src/main/resources/templates/boards/information_detail.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <link rel="stylesheet" type="text/css" th:href="@{/css/login.css?v1}">
+    <link rel="stylesheet" type="text/css" th:href="@{/css/base.css?v1}">
+    <link rel="stylesheet" type="text/css" th:href="@{/css/board.css?v1}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Nanum+Myeongjo:wght@700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600&display=swap" rel="stylesheet">
+    <title>Information Detail</title>
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@500&family=Skranji&display=swap');
+    </style>
+    <link rel='stylesheet' href='/webjars/bootstrap/4.5.0/css/bootstrap.min.css'>
+    <script>
+        $('.toggleDiv').on('click',function (){
+            this.next().toggle();
+        });
+    </script>
+</head>
+<body>
+<header th:insert="common/header.html"></header>
+<div class="container">
+    <div class="row" id="detailTop">
+        <h2 class="mr-auto" style="margin: 0 0 10px 20px">정보공유</h2>
+        <button th:if="${session.role == 'ROLE_USER' && session.id==board.member.id}"
+                class="signupBtn" type="button" style="background:none;border:none">
+            <a th:href="@{|//boards/information_update|}"
+               style="text-decoration: none;color: lightslategray;padding:10px">
+                수정
+            </a>
+        </button>
+        <button id="information_list" class="btn btn-primary" type="button"
+                style="background:none;border:none;color: lightslategray;padding:10px;margin:10px 0">이전</button>
+    </div>
+    <table class="table">
+        <thead>
+        <tr class="text-center">
+            <th scope="col">글번호: <span  th:text="${board.id}"></span></th>
+            <th scope="col">제목: <span th:text="${board.title}"></span></th>
+            <th scope="col">작성자: <span th:text="${board.writer}"></span></th>
+        </tr>
+        </thead>
+    </table>
+    <h6 style="float: right;color: #999999">
+        작성일자: <span th:text="${#temporals.format(board.createdDate, 'yyyy-MM-dd HH:mm')}"></span></h6>
+    <br>
+    <div style="height: 600px;">
+        <h3 style="margin-top: 50px"><span th:text="${board.content}"></span></h3>
+    </div>
+    <input type="hidden" name="iid" class="form-control" id="inputIid"  th:value="${board.id}" readonly>
+    <input type="hidden" name="userid" class="form-control" id="inputAuthor"  th:value="${session.userid}" readonly>
+    <div class="card" style="padding-bottom:10px">
+        <h3 style="padding: 20px 20px 0 30px">Comments</h3>
+        <ul class="list-group-flush" th:each="comment : ${commentList}" style="padding:0;margin:16px">
+            <li class="list-group-item">
+                <span>
+                    <span style="font-size: small" th:text="${comment.writer}"></span>
+                    <span style="font-size: xx-small"
+                          th:text="${#temporals.format(comment.createdDate, 'yyyy-MM-dd HH:mm')}"></span>
+                   </span>
+                <button th:if="${session.role == 'ROLE_USER' && session.id==comment.member.id}"
+                        type="button" style="background:none;border:none;">
+                    <a th:href="@{|/api/comments/${session.id}/${comment.id}|}">❌</a></button>
+                <div><span th:text="${comment.content}"></span></div>
+            </li>
+        </ul>
+    </div>
+    <br/>
+    <div th:if="${session.role == 'ROLE_USER'}" class="card">
+        <div class="col-sm-20" id="commentCard">
+            <textarea id="inputComment" type="text" name="comment" class="form-control"
+                      placeholder="댓글을 입력하세요" style="height:150px"></textarea>
+        </div>
+        <div class="col-auto ml-auto">
+            <input id = "comment-save" class="signupBtn" type="button" value="등록"
+                   style="margin-bottom: 20px;width:100px;height:38px">
+        </div>
+    </div>
+</div>
+<footer th:insert="common/footer.html"></footer>
+<script src="/webjars/jquery/3.5.1/jquery.min.js"></script>
+<script src="/webjars/bootstrap/4.5.0/js/bootstrap.min.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/boards/question_detail.html
+++ b/src/main/resources/templates/boards/question_detail.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <link rel="stylesheet" type="text/css" th:href="@{/css/login.css?v1}">
+    <link rel="stylesheet" type="text/css" th:href="@{/css/base.css?v1}">
+    <link rel="stylesheet" type="text/css" th:href="@{/css/board.css?v1}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Nanum+Myeongjo:wght@700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600&display=swap" rel="stylesheet">
+    <title>Question Detail</title>
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@500&family=Skranji&display=swap');
+    </style>
+    <link rel='stylesheet' href='/webjars/bootstrap/4.5.0/css/bootstrap.min.css'>
+    <script>
+        $('.toggleDiv').on('click',function (){
+            this.next().toggle();
+        });
+    </script>
+</head>
+<body>
+<header th:insert="common/header.html"></header>
+<div class="container">
+    <div class="row" id="detailTop">
+        <h2 class="mr-auto" style="margin: 0 0 10px 20px">QnA</h2>
+        <button th:if="${session.role == 'ROLE_USER' && session.id==board.member.id}"
+                class="signupBtn" type="button" style="background:none;border:none;padding:10px">
+            <a th:href="@{|/boards/question_update|}"
+               style="text-decoration: none;color: lightslategray">
+                수정
+            </a>
+        </button>
+        <button id="question_list" type="button"
+                style="background:none;border:none;color: lightslategray;padding:10px;margin:10px 0">이전</button>
+    </div>
+    <table class="table">
+        <thead>
+        <tr class="text-center">
+            <th scope="col">글 번호: <span th:text="${board.id}"></span></th>
+            <th scope="col">제목: <span th:text="${board.title}"></span></th>
+            <th scope="col">작성자: <span th:text="${board.writer}"></span></th>
+        </tr>
+        </thead>
+    </table>
+    <h6 style="float: right;color: #999999">
+        작성일자: <span th:text="${#temporals.format(board.createdDate, 'yyyy-MM-dd HH:mm')}"></span></h6>
+    <br>
+    <div style="height: 600px;">
+        <h3 style="margin-top: 50px"><span th:text="${board.content}"></span></h3>
+    </div>
+    <input type="hidden" name="qid" class="form-control" id="inputQid"  th:value="${board.id}" readonly>
+    <input type="hidden" name="userid" class="form-control" id="inputAuthor"  th:value="${session.userid}" readonly>
+    <div class="card" style="padding-bottom:10px">
+        <h3 style="padding: 20px 20px 0 30px">Comments</h3>
+        <ul class="list-group-flush" th:each="comment : ${commentList}" style="padding:0;margin:16px">
+            <li class="list-group-item">
+                <span>
+                    <input type="hidden" name="aid" class="form-control" id="inputAid"  th:value="${comment.id}" readonly>
+                    <span style="font-size: small" th:text="${comment.writer}"></span>
+                    <span style="font-size: xx-small"
+                          th:text="${#temporals.format(comment.createdDate, 'yyyy-MM-dd HH:mm')}"></span>
+                </span>
+                <button th:if="${session.role == 'ROLE_USER' && session.id == comment.member.id}"
+                        type="button" style="background:none;border:none;">
+                    <a th:href="@{|/api/comments/${session.id}/${comment.id}|}">❌</a></button>
+                <div><span th:text="${comment.content}"></span></div>
+            </li>
+        </ul>
+    </div>
+    <br/>
+    <div class="card" th:if="${session.role == 'ROLE_USER'}">
+        <div class="col-sm-20" id="commentCard">
+                <textarea id="inputComment" type="text" name="comment" class="form-control"
+                          placeholder="댓글을 입력하세요" style="height:150px"></textarea>
+        </div>
+        <div class="col-auto ml-auto">
+            <input id = "answer-save" class="signupBtn" type="button" value="등록"
+                   style="margin-bottom: 20px;width:100px;height:38px">
+        </div>
+    </div>
+</div>
+<footer th:insert="common/footer.html"></footer>
+<script src="/webjars/jquery/3.5.1/jquery.min.js"></script>
+<script src="/webjars/bootstrap/4.5.0/js/bootstrap.min.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/boards/question_list.html
+++ b/src/main/resources/templates/boards/question_list.html
@@ -38,7 +38,7 @@
                         <span th:text="${qna.id}"></span>
                     </th>
                     <td>
-                        <a th:href="@{|/question/detail/${qna.id}|}">
+                        <a th:href="@{|/api/boards/detail/${qna.id}|}">
                             <span th:text="${qna.title}"></span>
                         </a>
                     </td>


### PR DESCRIPTION
### SUMMARY
카테고리별 게시글 상세조회 UI 구현 및 연결한다
### DESCRIBE YOUR CHANGES
* 카테고리별 게시글 상세조회 UI 구현 및 연결
* question_list에 상세페이지 이동 url 수정
* 댓글 조회 api 일부 수정
  * List<Comment> -> List<CommentListResponse>로 전환 후 BoardResponse에 저장
### PR CHECKLIST
- [x] PR 템플릿에 맞춰서 작성하기
- [x] 모든 테스트 통과
- [x] 정상적으로 프로그램 실행 가능
- [x] 라벨 넣기
- [x] 불필요한 개행, 띄어쓰기, import문 제거

### OPTIONS
BoardResponse.getCommentList()로 댓글 목록을 가져오려다가 Dto 변환을 Comment측에서 처리하고 그 목록을 가져오는 것으로 수정
### ISSUE NUMBERS AND LINK
Closes #52 
